### PR TITLE
SetOnce attrs did not work in superclasses

### DIFF
--- a/Changes
+++ b/Changes
@@ -1,6 +1,6 @@
 Revision history for {{$dist->name}}
 
-{{$NEXT}}
+{{$NEXT}} SetOnce attributes now work in superclasses (Karen Etheridge)
 
 0.200000  2011-04-06 22:06:48 America/New_York
           more Moose 2.x bugfixes and tests (thanks Jesse Luehrs!)

--- a/lib/MooseX/SetOnce.pm
+++ b/lib/MooseX/SetOnce.pm
@@ -49,7 +49,7 @@ around _inline_set_value => sub {
   my @source = $self->$orig(@_);
 
   return (
-    'Class::MOP::class_of(' . $instance . ')->get_attribute(',
+    'Class::MOP::class_of(' . $instance . ')->find_attribute_by_name(',
       '\'' . quotemeta($self->name) . '\'',
     ')->_ensure_unset(' . $instance . ');',
     @source,
@@ -79,7 +79,7 @@ around _inline_store => sub {
   my ($orig, $self, $instance, $value) = @_;
 
   my $code = $self->$orig($instance, $value);
-  $code = sprintf qq[%s->meta->get_attribute("%s")->_ensure_unset(%s);\n%s],
+  $code = sprintf qq[%s->meta->find_attribute_by_name("%s")->_ensure_unset(%s);\n%s],
     $instance,
     quotemeta($self->associated_attribute->name),
     $instance,

--- a/t/inheritance.t
+++ b/t/inheritance.t
@@ -1,0 +1,37 @@
+use strict;
+use warnings;
+use Test::More;
+use Test::Fatal;
+use Test::Moose;
+
+use lib 'lib';
+require MooseX::SetOnce;
+
+{
+    package Fruit;
+    use Moose;
+
+    has color => (
+        is     => 'rw',
+        traits => [ qw(SetOnce) ],
+    );
+}
+
+{
+    package Apple;
+    use Moose;
+    extends 'Fruit';
+}
+
+with_immutable {
+    my $apple = Apple->new;
+
+    is(
+        exception { $apple->color('red') },
+        undef,
+        'SetOnce attributes can exist in a parent class',
+    );
+
+} 'Apple';
+
+done_testing;


### PR DESCRIPTION
See unit test - if a SetOnce attr was defined in a superclass, it was not usable in the subclass due to ->get_attribute($name) being used instead of ->find_attribute_by_name($name).

(Now from a shiny new fork from your github.) :)
